### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+declare module "lambda-multipart-parser" {
+    import {
+        APIGatewayProxyEvent,
+    } from "aws-lambda"
+
+    interface MultipartFile {
+        filename: string
+        content: Buffer
+        contentType: string
+        encoding: string
+        fieldname: string
+    }
+
+    type MultipartRequest = { files: MultipartFile[] } & Record<string, string>
+
+    export function parse (event: APIGatewayProxyEvent): Promise<MultipartRequest>
+}


### PR DESCRIPTION
First of all, thank you for this small but very useful library. It made my life a bit easier.

I'm developing some Lambda function on Typescript and I don't want to keep typings for dependencies in my repo. So I propose to put it here so it can work out of the box.

My example of AWS Lambdas on TypeScript for reference: https://github.com/Envek/aws-sam-typescript-layers-example/