### PR TITLE
Update busboy to 1.6.0, account for breaking changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const Busboy = require('busboy');
     }
  */
 const parse = (event) => new Promise((resolve, reject) => {
-    const busboy = new Busboy({
+    const busboy = Busboy({
         headers: {
             'content-type': event.headers['content-type'] || event.headers['Content-Type']
         }
@@ -30,7 +30,8 @@ const parse = (event) => new Promise((resolve, reject) => {
         files: []
     };
 
-    busboy.on('file', (fieldname, file, filename, encoding, mimetype) => {
+    busboy.on('file', (fieldname, file, info) => {
+        const { filename, encoding, mimeType } = info;
         const uploadFile = {};
 
         file.on('data', data => {
@@ -40,7 +41,7 @@ const parse = (event) => new Promise((resolve, reject) => {
         file.on('end', () => {
             if (uploadFile.content) {
                 uploadFile.filename = filename;
-                uploadFile.contentType = mimetype;
+                uploadFile.contentType = mimeType;
                 uploadFile.encoding = encoding;
                 uploadFile.fieldname = fieldname;
                 result.files.push(uploadFile);
@@ -56,7 +57,7 @@ const parse = (event) => new Promise((resolve, reject) => {
         reject(error);
     });
 
-    busboy.on('finish', () => {
+    busboy.on('close', () => {
         resolve(result);
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,824 @@
+{
+    "name": "lambda-multipart-parser",
+    "version": "1.0.1",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "lambda-multipart-parser",
+            "version": "1.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "busboy": "^1.6.0"
+            },
+            "devDependencies": {
+                "chai": "^3.5.0",
+                "mocha": "^2.5.3",
+                "sinon": "^6.3.1"
+            }
+        },
+        "node_modules/@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/commons/node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@sinonjs/formatio": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+            "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^3.1.0"
+            }
+        },
+        "node_modules/@sinonjs/formatio/node_modules/@sinonjs/samsam": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+            "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.3.0",
+                "array-from": "^2.1.1",
+                "lodash": "^4.17.15"
+            }
+        },
+        "node_modules/@sinonjs/samsam": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
+            "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
+            "dev": true
+        },
+        "node_modules/@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
+        "node_modules/array-from": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+            "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+            "dev": true
+        },
+        "node_modules/assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dependencies": {
+                "streamsearch": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.16.0"
+            }
+        },
+        "node_modules/chai": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+            "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+            "dev": true,
+            "dependencies": {
+                "assertion-error": "^1.0.1",
+                "deep-eql": "^0.1.3",
+                "type-detect": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/commander": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+            "integrity": "sha512-CD452fnk0jQyk3NfnK+KkR/hUPoHt5pVaKHogtyyv3N0U4QfAal9W0/rXLOg/vVZgQKa7jdtXypKs1YAip11uQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.x"
+            }
+        },
+        "node_modules/debug": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+            "dev": true,
+            "dependencies": {
+                "ms": "0.7.1"
+            }
+        },
+        "node_modules/deep-eql": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+            "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "0.1.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/deep-eql/node_modules/type-detect": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+            "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/diff": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+            "integrity": "sha512-VzVc42hMZbYU9Sx/ltb7KYuQ6pqAw+cbFWVy4XKdkuEL2CFaRLGEnISPs7YdzaUGpi+CpIqvRmu7hPQ4T7EQ5w==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+            "integrity": "sha512-cQpUid7bdTUnFin8S7BnNdOk+/eDqQmKgCANSyd/jAhrKEvxUvr9VQ8XZzXiOtest8NLfk3FSBZzwvemZNQ6Vg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/glob": {
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+            "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "2",
+                "minimatch": "0.3"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/growl": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+            "integrity": "sha512-RTBwDHhNuOx4F0hqzItc/siXCasGfC4DeWcBamclWd+6jWtBaeB/SGbMkGf0eiQoW7ib8JpvOgnUsmgMHI3Mfw==",
+            "dev": true
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+            "dev": true
+        },
+        "node_modules/jade": {
+            "version": "0.26.3",
+            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+            "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+            "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
+            "dev": true,
+            "dependencies": {
+                "commander": "0.6.1",
+                "mkdirp": "0.3.0"
+            },
+            "bin": {
+                "jade": "bin/jade"
+            }
+        },
+        "node_modules/jade/node_modules/commander": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+            "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4.x"
+            }
+        },
+        "node_modules/jade/node_modules/mkdirp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+            "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "dev": true
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "dev": true
+        },
+        "node_modules/lolex": {
+            "version": "2.7.5",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+            "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+            "dev": true
+        },
+        "node_modules/lru-cache": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+            "dev": true
+        },
+        "node_modules/minimatch": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+            "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+            "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+            "dev": true
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+            "dev": true,
+            "dependencies": {
+                "minimist": "0.0.8"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+            "integrity": "sha512-jNt2iEk9FPmZLzL+sm4FNyOIDYXf2wUU6L4Cc8OIKK/kzgMHKPi4YhTZqG4bW4kQVdIv6wutDybRhXfdnujA1Q==",
+            "dev": true,
+            "dependencies": {
+                "commander": "2.3.0",
+                "debug": "2.2.0",
+                "diff": "1.4.0",
+                "escape-string-regexp": "1.0.2",
+                "glob": "3.2.11",
+                "growl": "1.9.2",
+                "jade": "0.26.3",
+                "mkdirp": "0.5.1",
+                "supports-color": "1.2.0",
+                "to-iso-string": "0.0.2"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha"
+            },
+            "engines": {
+                "node": ">= 0.8.x"
+            }
+        },
+        "node_modules/ms": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg==",
+            "dev": true
+        },
+        "node_modules/nise": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+            "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/formatio": "^3.2.1",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "lolex": "^5.0.1",
+                "path-to-regexp": "^1.7.0"
+            }
+        },
+        "node_modules/nise/node_modules/lolex": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+            "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "dependencies": {
+                "isarray": "0.0.1"
+            }
+        },
+        "node_modules/sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
+        "node_modules/sinon": {
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.5.tgz",
+            "integrity": "sha512-xgoZ2gKjyVRcF08RrIQc+srnSyY1JDJtxu3Nsz07j1ffjgXoY6uPLf/qja6nDBZgzYYEovVkFryw2+KiZz11xQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.0.2",
+                "@sinonjs/formatio": "^3.0.0",
+                "@sinonjs/samsam": "^2.1.2",
+                "diff": "^3.5.0",
+                "lodash.get": "^4.4.2",
+                "lolex": "^2.7.5",
+                "nise": "^1.4.5",
+                "supports-color": "^5.5.0",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "node_modules/sinon/node_modules/diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/sinon/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/sinon/node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+            "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+            "dev": true,
+            "bin": {
+                "supports-color": "cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/to-iso-string": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+            "deprecated": "to-iso-string has been deprecated, use @segment/to-iso-string instead.",
+            "dev": true
+        },
+        "node_modules/type-detect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+            "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        }
+    },
+    "dependencies": {
+        "@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            },
+            "dependencies": {
+                "type-detect": {
+                    "version": "4.0.8",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+                    "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+                    "dev": true
+                }
+            }
+        },
+        "@sinonjs/formatio": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+            "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^3.1.0"
+            },
+            "dependencies": {
+                "@sinonjs/samsam": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+                    "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^1.3.0",
+                        "array-from": "^2.1.1",
+                        "lodash": "^4.17.15"
+                    }
+                }
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
+            "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
+            "dev": true
+        },
+        "@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
+        "array-from": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+            "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "dev": true
+        },
+        "busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "requires": {
+                "streamsearch": "^1.1.0"
+            }
+        },
+        "chai": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+            "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+            "dev": true,
+            "requires": {
+                "assertion-error": "^1.0.1",
+                "deep-eql": "^0.1.3",
+                "type-detect": "^1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+            "integrity": "sha512-CD452fnk0jQyk3NfnK+KkR/hUPoHt5pVaKHogtyyv3N0U4QfAal9W0/rXLOg/vVZgQKa7jdtXypKs1YAip11uQ==",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+            "dev": true,
+            "requires": {
+                "ms": "0.7.1"
+            }
+        },
+        "deep-eql": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+            "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+            "dev": true,
+            "requires": {
+                "type-detect": "0.1.1"
+            },
+            "dependencies": {
+                "type-detect": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                    "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+                    "dev": true
+                }
+            }
+        },
+        "diff": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+            "integrity": "sha512-VzVc42hMZbYU9Sx/ltb7KYuQ6pqAw+cbFWVy4XKdkuEL2CFaRLGEnISPs7YdzaUGpi+CpIqvRmu7hPQ4T7EQ5w==",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+            "integrity": "sha512-cQpUid7bdTUnFin8S7BnNdOk+/eDqQmKgCANSyd/jAhrKEvxUvr9VQ8XZzXiOtest8NLfk3FSBZzwvemZNQ6Vg==",
+            "dev": true
+        },
+        "glob": {
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+            "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+            "dev": true,
+            "requires": {
+                "inherits": "2",
+                "minimatch": "0.3"
+            }
+        },
+        "growl": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+            "integrity": "sha512-RTBwDHhNuOx4F0hqzItc/siXCasGfC4DeWcBamclWd+6jWtBaeB/SGbMkGf0eiQoW7ib8JpvOgnUsmgMHI3Mfw==",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+            "dev": true
+        },
+        "jade": {
+            "version": "0.26.3",
+            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+            "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
+            "dev": true,
+            "requires": {
+                "commander": "0.6.1",
+                "mkdirp": "0.3.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                    "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                    "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+                    "dev": true
+                }
+            }
+        },
+        "just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "dev": true
+        },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "dev": true
+        },
+        "lolex": {
+            "version": "2.7.5",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+            "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+            "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+            "integrity": "sha512-jNt2iEk9FPmZLzL+sm4FNyOIDYXf2wUU6L4Cc8OIKK/kzgMHKPi4YhTZqG4bW4kQVdIv6wutDybRhXfdnujA1Q==",
+            "dev": true,
+            "requires": {
+                "commander": "2.3.0",
+                "debug": "2.2.0",
+                "diff": "1.4.0",
+                "escape-string-regexp": "1.0.2",
+                "glob": "3.2.11",
+                "growl": "1.9.2",
+                "jade": "0.26.3",
+                "mkdirp": "0.5.1",
+                "supports-color": "1.2.0",
+                "to-iso-string": "0.0.2"
+            }
+        },
+        "ms": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg==",
+            "dev": true
+        },
+        "nise": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+            "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/formatio": "^3.2.1",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "lolex": "^5.0.1",
+                "path-to-regexp": "^1.7.0"
+            },
+            "dependencies": {
+                "lolex": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+                    "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^1.7.0"
+                    }
+                }
+            }
+        },
+        "path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "requires": {
+                "isarray": "0.0.1"
+            }
+        },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
+        "sinon": {
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.5.tgz",
+            "integrity": "sha512-xgoZ2gKjyVRcF08RrIQc+srnSyY1JDJtxu3Nsz07j1ffjgXoY6uPLf/qja6nDBZgzYYEovVkFryw2+KiZz11xQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.0.2",
+                "@sinonjs/formatio": "^3.0.0",
+                "@sinonjs/samsam": "^2.1.2",
+                "diff": "^3.5.0",
+                "lodash.get": "^4.4.2",
+                "lolex": "^2.7.5",
+                "nise": "^1.4.5",
+                "supports-color": "^5.5.0",
+                "type-detect": "^4.0.8"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "type-detect": {
+                    "version": "4.0.8",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+                    "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+                    "dev": true
+                }
+            }
+        },
+        "streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+        },
+        "supports-color": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+            "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+            "dev": true
+        },
+        "to-iso-string": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+            "dev": true
+        },
+        "type-detect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+            "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "multipart/formdata"
     ],
     "dependencies": {
-        "busboy": "^0.3.0"
+        "busboy": "^1.6.0"
     },
     "devDependencies": {
         "chai": "^3.5.0",


### PR DESCRIPTION
As in description. This accounts for [breaking changes from version 1.0.0 of busboy](https://github.com/mscdex/busboy/issues/266). 

Running the tests is successful. 