### PR TITLE
upgrade busboy to 1.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const Busboy = require('busboy');
     }
  */
 const parse = (event) => new Promise((resolve, reject) => {
-    const busboy = new Busboy({
+    const busboy =  Busboy({
         headers: {
             'content-type': event.headers['content-type'] || event.headers['Content-Type']
         }
@@ -30,9 +30,9 @@ const parse = (event) => new Promise((resolve, reject) => {
         files: []
     };
 
-    busboy.on('file', (fieldname, file, filename, encoding, mimetype) => {
+    busboy.on('file', (fieldname, file, info) => {
         const uploadFile = {};
-
+        const { filename, encoding, mimeType } = info;
         file.on('data', data => {
             uploadFile.content = data;
         });
@@ -40,7 +40,7 @@ const parse = (event) => new Promise((resolve, reject) => {
         file.on('end', () => {
             if (uploadFile.content) {
                 uploadFile.filename = filename;
-                uploadFile.contentType = mimetype;
+                uploadFile.contentType = mimeType;
                 uploadFile.encoding = encoding;
                 uploadFile.fieldname = fieldname;
                 result.files.push(uploadFile);
@@ -56,7 +56,7 @@ const parse = (event) => new Promise((resolve, reject) => {
         reject(error);
     });
 
-    busboy.on('finish', () => {
+    busboy.on('close', () => {
         resolve(result);
     });
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "multipart/formdata"
     ],
     "dependencies": {
-        "busboy": "^0.3.0"
+        "busboy": "1.6.0"
     },
     "devDependencies": {
         "chai": "^3.5.0",


### PR DESCRIPTION
Reasoning: busboy 0.3.0 depends of dicer 0.3.0 which has a vulnerability before 0.3.1:
"This affects all versions of package dicer. A malicious attacker can send a modified form to server, and crash the nodejs service. A complete denial of service can be achived by sending the malicious form in a loop."
